### PR TITLE
Tidy up TypeScript definition, add simple tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,60 +1,58 @@
 export as namespace Unist
 
-declare namespace Unist {
-  // Syntactic units in unist syntax trees are called nodes.
-  export interface Node {
-    // The variant of a node.
-    type: string
+// Syntactic units in unist syntax trees are called nodes.
+export interface Node {
+  // The variant of a node.
+  type: string
 
-    // Information from the ecosystem.
-    data?: Data
+  // Information from the ecosystem.
+  data?: Data
 
-    // Location of a node in a source document.
-    // Must not be present if a node is generated.
-    position?: Position
-  }
+  // Location of a node in a source document.
+  // Must not be present if a node is generated.
+  position?: Position
+}
 
-  // Location of a node in a source file.
-  export interface Position {
-    // Place of the first character of the parsed source region.
-    start: Point
+// Location of a node in a source file.
+export interface Position {
+  // Place of the first character of the parsed source region.
+  start: Point
 
-    // Place of the first character after the parsed source region.
-    end: Point
+  // Place of the first character after the parsed source region.
+  end: Point
 
-    // Start column at each index (plus start line) in the source region,
-    // for elements that span multiple lines.
-    indent: number[]
-  }
+  // Start column at each index (plus start line) in the source region,
+  // for elements that span multiple lines.
+  indent: number[]
+}
 
-  // One place in a source file.
-  export interface Point {
-    // Line in a source file (1-indexed integer).
-    line: number
+// One place in a source file.
+export interface Point {
+  // Line in a source file (1-indexed integer).
+  line: number
 
-    // Column in a source file (1-indexed integer).
-    column: number
+  // Column in a source file (1-indexed integer).
+  column: number
 
-    // Character in a source file (0-indexed integer).
-    offset: number
-  }
+  // Character in a source file (0-indexed integer).
+  offset: number
+}
 
-  // Information associated by the ecosystem with the node.
-  // Space is guaranteed to never be specified by unist or specifications
-  // implementing unist.
-  export interface Data {
-    [key: string]: unknown
-  }
+// Information associated by the ecosystem with the node.
+// Space is guaranteed to never be specified by unist or specifications
+// implementing unist.
+export interface Data {
+  [key: string]: unknown
+}
 
-  // Nodes containing other nodes.
-  export interface Parent extends Node {
-    // List representing the children of a node.
-    children: Node[]
-  }
+// Nodes containing other nodes.
+export interface Parent extends Node {
+  // List representing the children of a node.
+  children: Node[]
+}
 
-  // Nodes containing a value.
-  export interface Literal extends Node {
-    // Any value
-    value: unknown
-  }
+// Nodes containing a value.
+export interface Literal extends Node {
+  // Any value
+  value: unknown
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
     "prettier": "^1.14.2",
     "remark-cli": "^5.0.0",
     "remark-preset-wooorm": "^4.0.0",
-    "typescript": "^3.0.1"
+    "ts-node": "^7.0.1",
+    "typescript": "^3.0.3"
   },
   "scripts": {
     "format": "remark . -qfo && prettier --write \"**/*.ts\"",
-    "test-types": "tsc index.d.ts mdast.d.ts",
+    "test-types": "ts-node test.ts",
     "test": "npm run format && npm run test-types"
   },
   "prettier": {

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,22 @@
+import {Node, Data, Literal, Parent} from './index'
+
+const data: Data = {}
+
+const node: Node = {
+  type: 'node',
+  data: data
+}
+
+const literal: Literal = {
+  type: 'literal',
+  value: 123
+}
+
+const parent: Parent = {
+  type: 'parent',
+  children: [node, literal]
+}
+
+console.log(node)
+console.log(literal)
+console.log(parent)


### PR DESCRIPTION
Related to https://github.com/syntax-tree/unist-ts/issues/1, nothing exciting but a small tidy up and added `test.ts` so you can validate it works as expected in TypeScript and node.js.